### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/cgiacofei/flexget.png?label=ready&title=Ready)](https://waffle.io/cgiacofei/flexget)
 # Flexget Configuration #
 
 Main episode grabbing tasks work through trakt.tv


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/cgiacofei/flexget

This was requested by a real person (user cgiacofei) on waffle.io, we're not trying to spam you.
